### PR TITLE
fixed session state not refreshing after deletion

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -8,11 +8,12 @@ import { useSessions } from '../state/SessionsContext';
 
 export const Calendar = () => {
   const { myShows, getMyShows } = useShows();
-  const { mySessions } = useSessions();
+  const { mySessions, refreshSessions } = useSessions();
   const navigate = useNavigate();
 
   useEffect(() => {
     getMyShows();
+    refreshSessions();
   }, []);
 
   const showCalendarData = myShows.map((show) => ({


### PR DESCRIPTION
If a user deleted a session, that session would still be visible on the calendar, and only refresh when the user refreshes the page. I added a session state refresh to the useEffect hook in the sessions context to fix this issue.